### PR TITLE
fix example panic caused by nil pointer error

### DIFF
--- a/juju/example/krakend.json
+++ b/juju/example/krakend.json
@@ -1,8 +1,8 @@
 {
-    "version": 1,
+    "version": 2,
     "name": "TV shows gateway",
     "port": 8080,
-    "cache_ttl": 3600,
+    "cache_ttl": "3600s",
     "timeout": "3s",
     "endpoints": [
         {

--- a/juju/example/main.go
+++ b/juju/example/main.go
@@ -5,15 +5,15 @@ import (
 	"log"
 	"os"
 
+	jujuproxy "github.com/devopsfaith/krakend-ratelimit/juju/proxy"
+	jujurouter "github.com/devopsfaith/krakend-ratelimit/juju/router/gin"
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/devopsfaith/krakend/proxy"
 	krakendgin "github.com/devopsfaith/krakend/router/gin"
 	"github.com/devopsfaith/krakend/transport/http/client"
+	http "github.com/devopsfaith/krakend/transport/http/server"
 	"github.com/gin-gonic/gin"
-
-	jujuproxy "github.com/devopsfaith/krakend-ratelimit/juju/proxy"
-	jujurouter "github.com/devopsfaith/krakend-ratelimit/juju/router/gin"
 )
 
 func main() {
@@ -44,6 +44,7 @@ func main() {
 		Middlewares:    []gin.HandlerFunc{},
 		Logger:         logger,
 		HandlerFactory: jujurouter.HandlerFactory,
+		RunServer:      http.RunServer,
 	})
 
 	routerFactory.New().Run(serviceConfig)

--- a/rate/example/krakend.json
+++ b/rate/example/krakend.json
@@ -1,8 +1,8 @@
 {
-    "version": 1,
+    "version": 2,
     "name": "TV shows gateway",
     "port": 8080,
-    "cache_ttl": 3600,
+    "cache_ttl": "3600s",
     "timeout": "3s",
     "endpoints": [
         {

--- a/rate/example/main.go
+++ b/rate/example/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devopsfaith/krakend/proxy"
 	krakendgin "github.com/devopsfaith/krakend/router/gin"
 	"github.com/devopsfaith/krakend/transport/http/client"
+	http "github.com/devopsfaith/krakend/transport/http/server"
 	"github.com/gin-gonic/gin"
 
 	rateproxy "github.com/devopsfaith/krakend-ratelimit/rate/proxy"
@@ -44,6 +45,7 @@ func main() {
 		Middlewares:    []gin.HandlerFunc{},
 		Logger:         logger,
 		HandlerFactory: raterouter.HandlerFactory,
+		RunServer:      http.RunServer,
 	})
 
 	routerFactory.New().Run(serviceConfig)


### PR DESCRIPTION
- Must pass `RunServer` to config when invoke `ginrouter.NewFactory`.
- tweak config file

---

panic stack:

```
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x15ae3dc]

goroutine 1 [running]:
github.com/devopsfaith/krakend/router/gin.ginRouter.Run(0xc000234000, 0x1ca10f8, 0x0, 0x0, 0xc00019a330, 0x1815c20, 0xc000198260, 0x182dc40, 0xc00019e8e0, 0x0, ...)
	/Users/x1ah/workspace/go/pkg/mod/github.com/devopsfaith/krakend@v0.0.0-20190930092458-9e6fc3784eca/router/gin/router.go:96 +0x3bc
main.main()
	/Users/x1ah/workspace/extra/krakend-ratelimit/juju/example/main.go:50 +0x506
exit status 2
```