### PR TITLE
support for customized X-Forwarded-For headers added

### DIFF
--- a/juju/router/gin/gin_test.go
+++ b/juju/router/gin/gin_test.go
@@ -1,0 +1,116 @@
+package gin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/devopsfaith/krakend-ratelimit/juju/router"
+	"github.com/devopsfaith/krakend/config"
+	"github.com/devopsfaith/krakend/proxy"
+	"github.com/gin-gonic/gin"
+)
+
+func TestNewRateLimiterMw_CustomHeaderIP(t *testing.T) {
+	header := "X-Custom-Forwarded-For"
+
+	cfg := &config.EndpointConfig{
+		ExtraConfig: map[string]interface{}{
+			router.Namespace: map[string]interface{}{
+				"strategy":      "ip",
+				"clientMaxRate": 100,
+				"key":           header,
+			},
+		},
+	}
+
+	rd := func(req *http.Request) {
+		req.Header.Add(header, "1.1.1.1,2.2.2.2,3.3.3.3")
+	}
+
+	testRateLimiterMw(t, rd, cfg)
+}
+
+func TestNewRateLimiterMw_CustomHeader(t *testing.T) {
+	header := "X-Custom-Forwarded-For"
+
+	cfg := &config.EndpointConfig{
+		ExtraConfig: map[string]interface{}{
+			router.Namespace: map[string]interface{}{
+				"strategy":      "header",
+				"clientMaxRate": 100,
+				"key":           header,
+			},
+		},
+	}
+
+	rd := func(req *http.Request) {
+		req.Header.Add(header, "1.1.1.1,2.2.2.2,3.3.3.3")
+	}
+
+	testRateLimiterMw(t, rd, cfg)
+}
+
+func TestNewRateLimiterMw_DefaultIP(t *testing.T) {
+	cfg := &config.EndpointConfig{
+		ExtraConfig: map[string]interface{}{
+			router.Namespace: map[string]interface{}{
+				"strategy":      "ip",
+				"clientMaxRate": 100,
+			},
+		},
+	}
+
+	rd := func(req *http.Request) {}
+
+	testRateLimiterMw(t, rd, cfg)
+}
+
+type requestDecorator func(*http.Request)
+
+func testRateLimiterMw(t *testing.T, rd requestDecorator, cfg *config.EndpointConfig) {
+	var hits, ok, ko int64
+	p := func(ctx context.Context, req *proxy.Request) (*proxy.Response, error) {
+		atomic.AddInt64(&hits, 1)
+		return &proxy.Response{}, nil
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	r.GET("/", HandlerFactory(cfg, p))
+
+	total := 10000
+	start := time.Now()
+	for i := 0; i < total; i++ {
+		req, _ := http.NewRequest("GET", "/", nil)
+		rd(req)
+		w := httptest.NewRecorder()
+
+		r.ServeHTTP(w, req)
+		if w.Result().StatusCode == 200 {
+			ok++
+			continue
+		}
+		if w.Result().StatusCode == 429 {
+			ko++
+			continue
+		}
+	}
+
+	if hits != ok {
+		t.Errorf("hits do not match the tracked oks: %d/%d", hits, ok)
+	}
+
+	if d := time.Since(start); d > time.Second {
+		return
+	}
+
+	if ok+ko != int64(total) {
+		t.Errorf("not all the requests were tracked: %d/%d", ok, ko)
+	}
+
+}


### PR DESCRIPTION
this pr extends the `ip` strategy of the juju-based router rate limiter middleware, so if a `key` param is present at the config, the token extractor will try to extract the client's IP from the given header and fallback to the default IP extractor if it can't 