### PR TITLE
Rate limit per JWT claim

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.13
 require (
 	github.com/devopsfaith/krakend v0.0.0-20190930092458-9e6fc3784eca
 	github.com/gin-gonic/gin v1.4.0
+	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/juju/ratelimit v1.0.1
+	github.com/tidwall/gjson v1.7.4
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/golang/protobuf v1.0.0 h1:lsek0oXi8iFE9L+EXARyHIjU5rlWIhhTkjDz3vHhWWQ
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -43,6 +44,12 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tidwall/gjson v1.7.4 h1:19cchw8FOxkG5mdLRkGf9jqIqEyqdZhPqW60XfyFxk8=
+github.com/tidwall/gjson v1.7.4/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
+github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.1.0 h1:K3hMW5epkdAVwibsQEfR/7Zj0Qgt4DxtNumTq/VloO8=
+github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/ugorji/go v0.0.0-20180112141927-9831f2c3ac10 h1:4zp+5ElNBLy5qmaDFrbVDolQSOtPmquw+W6EMNEpi+k=
 github.com/ugorji/go v0.0.0-20180112141927-9831f2c3ac10/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
@@ -61,6 +68,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=

--- a/juju/example/krakend.json
+++ b/juju/example/krakend.json
@@ -37,6 +37,28 @@
             ],
             "extra_config": {
                 "github.com/devopsfaith/krakend-ratelimit/juju/router": {
+                    "tierConfiguration": {
+                        "jwtClaim": "tier",
+                        "duration": "1m",
+                        "tiers": [
+                            {
+                                "name": "unlimited",
+                                "limit": 0
+                            },
+                            {
+                                "name": "gold",
+                                "limit": 50
+                            },
+                            {
+                                "name": "silver",
+                                "limit": 20
+                            },
+                            {
+                                "name": "bronze",
+                                "limit": 5
+                            }
+                        ]
+                    },
                     "maxRate": 50,
                     "clientMaxRate": 5,
                     "strategy": "ip"


### PR DESCRIPTION
We have a use-case where different clients have a different number of request they can make to the API.

We implemented this in our custom KrakenD build, but I'm opening this PR in case you're interested.

Basically, we added a `tierConfiguration` block under `github.com/devopsfaith/krakend-ratelimit/juju/router`'s `extra_config`:

```json
"tierConfiguration": {
  "jwtClaim": "tier",
  "duration": "24h",
  "tiers": [
    {
      "name": "unlimited",
      "limit": 0
    },
    {
      "name": "gold",
      "limit": 50000
    },
    {
      "name": "silver",
      "limit": 20000
    },
    {
      "name": "bronze",
      "limit": 5000
    }
  ]
}
```

In the example above, a client in the `gold` tier has 50k request per day, and so on.